### PR TITLE
Set screen output by default in case of rosbag playing

### DIFF
--- a/launch/audio_to_spectrogram.launch
+++ b/launch/audio_to_spectrogram.launch
@@ -25,7 +25,8 @@
     <param name="use_sim_time" value="true" />
     <node name="rosbag_play"
           pkg="rosbag" type="play"
-          args="$(arg filename) --clock --pause"/>
+          args="$(arg filename) --clock --pause"
+          output="screen" />
   </group>
   <group unless="$(arg use_rosbag)" >
     <node name="audio_capture" pkg="audio_capture" type="audio_capture"


### PR DESCRIPTION
In readme, the description that rosbag is paused at first is written down.
However, it is easy for the user to understand the output of `rosbag play`.